### PR TITLE
Neperzistovať `frontend_build` volume v Dockeri

### DIFF
--- a/docker/dev.ps1
+++ b/docker/dev.ps1
@@ -19,4 +19,4 @@ if (-not $env:DB_PASSWORD) {
 }
 
 # run (default profile - HTTP only)
-docker compose --profile="default" -f docker-compose.yaml up -d --build
+docker compose --profile="default" -f docker-compose.yaml up --build -d --force-recreate

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -17,4 +17,4 @@ export DB_ROOT_PASSWORD
 export DB_PASSWORD
 
 # run (default profile - HTTP only)
-docker compose --profile="default" -f docker-compose.yaml up -d --build
+docker compose --profile="default" -f docker-compose.yaml up --build -d --force-recreate

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,7 +22,6 @@ services:
     build: ../frontend
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - frontend_build:/usr/share/nginx/html:ro
     ports:
       - "80:80"
     profiles: ["default", "https"]
@@ -31,7 +30,6 @@ services:
     build: ../frontend
     volumes:
       - ./nginx/nginx.https.conf:/etc/nginx/nginx.conf:ro
-      - frontend_build:/usr/share/nginx/html:ro
       - certs:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
     ports:
@@ -69,4 +67,3 @@ services:
 volumes:
   db_data:
   certs:
-  frontend_build:


### PR DESCRIPTION
Zrýchli čas spúšťania Dockeru a dovolí update kódu bez potreby ničiť `frontend_build` volume